### PR TITLE
Use ⎕NS in Model Constructor

### DIFF
--- a/OpenAPIDyalog/Templates/APLSource/models/model.aplc.scriban
+++ b/OpenAPIDyalog/Templates/APLSource/models/model.aplc.scriban
@@ -10,7 +10,7 @@
     :field public {{ prop.dyalog_name }} ⍝ {{ prop.type }}
     {{~ end ~}}
 
-    ∇ make1 args;names
+    ∇ make1 args
         :Access public
         :Implements constructor
         ⍝ We will assume correct


### PR DESCRIPTION
Instead of manually setting every variable, we can take all args and copy them to ⎕THIS. If the args are being passed properly, there should be no issue.

Fixes #9 