### PR TITLE
Force arrays to be arrays

### DIFF
--- a/OpenAPIDyalog/Templates/APLSource/models/model.aplc.scriban
+++ b/OpenAPIDyalog/Templates/APLSource/models/model.aplc.scriban
@@ -30,13 +30,18 @@
             :If 0∊⍴{{ prop.dyalog_name }}
                 build.{{ prop.api_name }}←⍬
             :Else
-                build.{{ prop.api_name }}←{{ prop.dyalog_name }}.FormatNS
+                build.{{ prop.api_name }}←1∘/{{ prop.dyalog_name }}.FormatNS ⍝ Ensure minimum rank 1
             :EndIf 
             {{~ else ~}}
                 build.{{ prop.api_name }}←{{ prop.dyalog_name }}.FormatNS
             {{~ end ~}}
             {{~ else ~}}
+
+            {{~ if prop.is_array ~}}
+            build.{{ prop.api_name }}←1∘/⊆{{ prop.dyalog_name }} 
+            {{~ else ~}}
             build.{{ prop.api_name }}←{{ prop.dyalog_name }} 
+            {{~ end ~}}
             {{~ end ~}}
         :EndIf
 


### PR DESCRIPTION
This pull request updates the template logic in `OpenAPIDyalog/Templates/APLSource/models/model.aplc.scriban` to ensure consistent handling of array properties and maintain minimum rank for certain assignments. The changes primarily improve how arrays and nested arrays are formatted and assigned in the generated APL code.

**Enhancements to array handling and formatting:**

* Ensured that when assigning `{{ prop.api_name }}` from `{{ prop.dyalog_name }}`, the result always has at least rank 1 by applying `1∘/` to the output of `.FormatNS` for non-empty arrays.
* Added logic to wrap array properties using `1∘/⊆` to guarantee proper array structure when assigning to `build.{{ prop.api_name }}` for properties marked as arrays.

Fixes #17 