### PR TITLE
Header Parameter Support

### DIFF
--- a/OpenAPIDyalog/Templates/APLSource/Client.aplc.scriban
+++ b/OpenAPIDyalog/Templates/APLSource/Client.aplc.scriban
@@ -72,6 +72,7 @@
         ⍝ cArgs is a NS that mostly contains HttpCommand args
         cArgs.BaseURL←BaseURL
         ⍝cArgs.Headers←Headers
+        cArgs.Headers,←'User-Agent' ((' Dyalog OpenAPI Generated Client',2⊃Version),⍨'Dyalog-',1↓∊'/',¨2↑HttpCommand.Version)
         cArgs.TranslateData←1
         r←HttpCommand.Do cArgs
     ∇

--- a/OpenAPIDyalog/Templates/APLSource/api/endpoint.apln.scriban
+++ b/OpenAPIDyalog/Templates/APLSource/api/endpoint.apln.scriban
@@ -71,13 +71,11 @@
             Command: '{{ method }}'
             URL: {{ dyalog_path }}
             ContentType: '{{ request_content_type ?? "application/json" }}'
+            Headers: headerParams
             {{ if request_content_type }}Params: params{{ end }}
         )
         :If 0≠⍴queryParams.⎕NL-⍳9
             r.URL,←'?',args.client.HttpCommand.UrlEncode queryParams
-        :EndIf
-        :If 0≠⍴headerParams
-            r.Headers←headerParams
         :EndIf
     ∇ 
 


### PR DESCRIPTION
This pull request implements generation of HTTP headers in the generated Dyalog OpenAPI client. The main improvements include support for custom header parameters in endpoint functions and the addition of a standard `User-Agent` header in all outgoing requests.

Resolves #20

**Header handling improvements:**

* Endpoint argument parsing now collects header parameters into a new `headerParams` variable, allowing endpoints to accept and forward custom HTTP headers.
* The generated HTTP command now includes these `headerParams` in the request, ensuring headers specified by the user are sent with API calls.

**Standardization of outgoing requests:**

* All outgoing requests now include a standardized `User-Agent` header, identifying the client as a Dyalog OpenAPI generated client and including version information.